### PR TITLE
T/opencast 2560 fix uct av left work

### DIFF
--- a/files/config/default/etc/encoding/uct.properties
+++ b/files/config/default/etc/encoding/uct.properties
@@ -341,21 +341,21 @@ profile.uct-av-left.work.name = Re-encode audiovisual track (Left)
 profile.uct-av-left.work.input = stream
 profile.uct-av-left.work.output = audiovisual
 profile.uct-av-left.work.suffix = -work.#{in.video.suffix}
-profile.uct-av-left.work.ffmpeg.command = -i #{in.video.path} -shortest -af "pan=mono|c0=FL+FC" -r:v 25 -c:v libx264 -c:a flac -preset veryfast -pix_fmt yuv420p -crf 18 #{out.dir}/#{out.name}#{out.suffix}
+profile.uct-av-left.work.ffmpeg.command = -i #{in.video.path} -shortest -af "pan=mono|c0=FL+FC" -r:v 25 -c:v libx264 -c:a flac -preset veryfast -pix_fmt yuv420p -crf 18 -max_muxing_queue_size 1024 #{out.dir}/#{out.name}#{out.suffix}
 profile.uct-av-left.work.jobload = 2.5
 
 profile.uct-av-right.work.name = Re-encode audiovisual track (Right)
 profile.uct-av-right.work.input = stream
 profile.uct-av-right.work.output = audiovisual
 profile.uct-av-right.work.suffix = -work.#{in.video.suffix}
-profile.uct-av-right.work.ffmpeg.command = -i #{in.video.path} -shortest -af "pan=mono|c0=FR+FC" -r:v 25 -c:v libx264 -c:a flac -preset veryfast -pix_fmt yuv420p -crf 18 #{out.dir}/#{out.name}#{out.suffix}
+profile.uct-av-right.work.ffmpeg.command = -i #{in.video.path} -shortest -af "pan=mono|c0=FR+FC" -r:v 25 -c:v libx264 -c:a flac -preset veryfast -pix_fmt yuv420p -crf 18 -max_muxing_queue_size 1024 #{out.dir}/#{out.name}#{out.suffix}
 profile.uct-av-right.work.jobload = 2.5
 
 profile.uct-av-stereo.work.name = Re-encode audiovisual track (stereo)
 profile.uct-av-stereo.work.input = stream
 profile.uct-av-stereo.work.output = audiovisual
 profile.uct-av-stereo.work.suffix = -work.#{in.video.suffix}
-profile.uct-av-stereo.work.ffmpeg.command = -i #{in.video.path} -shortest -r:v 25 -c:v libx264 -preset veryfast -pix_fmt yuv420p -crf 18 -max_muxing_queue_size 1024 #{out.dir}/#{out.name}#{out.suffix}
+profile.uct-av-stereo.work.ffmpeg.command = -i #{in.video.path} -shortest -r:v 25 -c:v libx264 -preset veryfast -pix_fmt yuv420p -crf 18 -max_muxing_queue_size 1024 -max_muxing_queue_size 1024 #{out.dir}/#{out.name}#{out.suffix}
 profile.uct-av-stereo.work.jobload = 2.5
 
 # TESTING - same as above but with added scaling to 720

--- a/files/config/default/etc/encoding/uct.properties
+++ b/files/config/default/etc/encoding/uct.properties
@@ -337,25 +337,28 @@ profile.uct-mux-av-right.work.jobload = 2.5
 #   file and muxes them into the same kind of container they were in before. A
 #   general re-encoding will not happen, but if the duration of both streams
 #   differ, the longer one will be cut.
+#   Before: work.suffix = -work.#{in.video.suffix}
+#   After:  work.suffix = -work.mkv
+
 profile.uct-av-left.work.name = Re-encode audiovisual track (Left)
 profile.uct-av-left.work.input = stream
 profile.uct-av-left.work.output = audiovisual
-profile.uct-av-left.work.suffix = -work.#{in.video.suffix}
+profile.uct-av-left.work.suffix = -work.mkv
 profile.uct-av-left.work.ffmpeg.command = -i #{in.video.path} -shortest -af "pan=mono|c0=FL+FC" -r:v 25 -c:v libx264 -c:a flac -preset veryfast -pix_fmt yuv420p -crf 18 -max_muxing_queue_size 1024 #{out.dir}/#{out.name}#{out.suffix}
 profile.uct-av-left.work.jobload = 2.5
 
 profile.uct-av-right.work.name = Re-encode audiovisual track (Right)
 profile.uct-av-right.work.input = stream
 profile.uct-av-right.work.output = audiovisual
-profile.uct-av-right.work.suffix = -work.#{in.video.suffix}
+profile.uct-av-right.work.suffix = -work.mkv
 profile.uct-av-right.work.ffmpeg.command = -i #{in.video.path} -shortest -af "pan=mono|c0=FR+FC" -r:v 25 -c:v libx264 -c:a flac -preset veryfast -pix_fmt yuv420p -crf 18 -max_muxing_queue_size 1024 #{out.dir}/#{out.name}#{out.suffix}
 profile.uct-av-right.work.jobload = 2.5
 
 profile.uct-av-stereo.work.name = Re-encode audiovisual track (stereo)
 profile.uct-av-stereo.work.input = stream
 profile.uct-av-stereo.work.output = audiovisual
-profile.uct-av-stereo.work.suffix = -work.#{in.video.suffix}
-profile.uct-av-stereo.work.ffmpeg.command = -i #{in.video.path} -shortest -r:v 25 -c:v libx264 -preset veryfast -pix_fmt yuv420p -crf 18 -max_muxing_queue_size 1024 -max_muxing_queue_size 1024 #{out.dir}/#{out.name}#{out.suffix}
+profile.uct-av-stereo.work.suffix = -work.mkv
+profile.uct-av-stereo.work.ffmpeg.command = -i #{in.video.path} -shortest -r:v 25 -c:v libx264 -preset veryfast -pix_fmt yuv420p -crf 18 -max_muxing_queue_size 1024 #{out.dir}/#{out.name}#{out.suffix}
 profile.uct-av-stereo.work.jobload = 2.5
 
 # TESTING - same as above but with added scaling to 720


### PR DESCRIPTION
Changed the output format suffix to use mkv so that the audio, which is encoded to flac in the profile is used.