### PR TITLE
OPENCAST-2405: Updated script to handle errors and fail at appropriate times

### DIFF
--- a/files/worker/wfexec/event-timetable.pl
+++ b/files/worker/wfexec/event-timetable.pl
@@ -216,7 +216,7 @@ sub getEventDetails($$$) {
     return ($series, $event_date, $duration, $title, $start_time, $end_time);
 }
 
-# Do a REST call to OC and retreive JSON based on the URL
+# Do a REST call to OC and retrieve JSON based on the URL
 sub getMetadata($$$) {
     my $mech = shift;
     my $url = shift;

--- a/files/worker/wfexec/event-timetable.pl
+++ b/files/worker/wfexec/event-timetable.pl
@@ -4,9 +4,6 @@ use strict;
 
 use Data::Dumper;
 use WWW::Mechanize;
-use LWP::Protocol::https;
-use DateTime;
-use DateTime::Duration;
 use DateTime::Format::Duration;
 use DateTime::Format::W3CDTF;
 use Attempt;
@@ -15,6 +12,7 @@ use JSON;
 my $debug = 0;
 my $oc_config = "/opt/opencast/etc/custom.properties";
 my $tt_ws = "https://srvslscet001.uct.ac.za/timetable/";
+my $this_timezone = 'Africa/Johannesburg';
 
 my %tt_comment;
 $tt_comment{'true'}  = "TIMETABLED event: edit and publish";
@@ -205,7 +203,7 @@ sub getEventDetails($$$) {
         $title      = getEventField($event_m, "title", 0);
         $location   = getEventField($event_m, "location", 0);
 
-        my $local_time = $event_date->clone()->set_time_zone('GMT')->set_time_zone('Africa/Johannesburg');
+        my $local_time = $event_date->clone()->set_time_zone('GMT')->set_time_zone($this_timezone);
         my $local_end_time = $local_time + $dfd_t->parse_duration($duration);
 
         $start_time = $local_time->strftime("%H:%M");

--- a/files/worker/wfexec/event-timetable.pl
+++ b/files/worker/wfexec/event-timetable.pl
@@ -68,7 +68,7 @@ if ((index(lc($title), "[backup]") != -1) || (index(lc($title), "[hold]") != -1)
     $event_trim = "false";
 }
 
-## Get the series info
+# Get the series info
 if (defined($series) && $series ne "") {
 
     ($visibility, $course, $caption_provider) = getSeriesDetails($mech, $server, $series);
@@ -83,7 +83,7 @@ if (defined($series) && $series ne "") {
             die "Course Code ERROR: ". $course;
         }
 
-        ## Check with the timetable webservice
+        # Check with the timetable webservice
         if (($course =~ /[\w]{3}[\d]{4}[\w]{1},[\d]{4}/) && defined($event_date) && defined($start_time) && defined($end_time) && defined($location)) {
 
             my ($st, $et) = adjustCheckTime($start_time, $end_time);
@@ -102,7 +102,7 @@ if (defined($series) && $series ne "") {
     }
 }
 
-## Conclusion
+# Conclusion
 if (($tt_result eq "true") && ($visibility ne "public")) {
     $timetabled = "true";
 }
@@ -130,29 +130,28 @@ exit 0;
 # Get the digest auth configuration from the local config file
 sub getOcAuth($) {
 
-  my $propsfile = shift;
+    my $propsfile = shift;
 
-  my $url;
-  my $user;
-  my $pass;
+    my $url;
+    my $user;
+    my $pass;
 
-  open FILE, '<', $propsfile or die "Unable to open local Opencast properties file: $!\n";
-  while(<FILE>) {
-    chomp;
-    if ($_ =~ /^org.opencastproject.security.digest.user=(.*)$/) {
-      $user = $1;
+    open FILE, '<', $propsfile or die "Unable to open local Opencast properties file: $!\n";
+    while(<FILE>) {
+        chomp;
+        if ($_ =~ /^org.opencastproject.security.digest.user=(.*)$/) {
+            $user = $1;
+        }
+        if ($_ =~ /^org.opencastproject.security.digest.pass=(.*)$/) {
+            $pass = $1;
+        }
+        if ($_ =~ /^org.opencastproject.admin.ui.url=(.*)$/) {
+            $url = $1;
+        }
     }
-    if ($_ =~ /^org.opencastproject.security.digest.pass=(.*)$/) {
-      $pass = $1;
-    }
-    if ($_ =~ /^org.opencastproject.admin.ui.url=(.*)$/) {
-      $url = $1;
-    }
+    close FILE;
 
-  }
-  close FILE;
-
-  return ($url, $user, $pass);
+    return ($url, $user, $pass);
 }
 
 # Series Metadata
@@ -228,10 +227,11 @@ sub getEventDetails($$$) {
     return ($series, $event_date, $duration, $title, $start_time, $end_time);
 }
 
+# Do a REST call to OC and retreive JSON based on the URL
 sub getMetadata($$$) {
     my $mech = shift;
     my $url = shift;
-    my $encode = shift;
+    my $decode = shift;
 
     $mech->get($url);
     $numEventAttempts++;
@@ -244,7 +244,7 @@ sub getMetadata($$$) {
             die "Metadata ERROR [". $response->status_line ."]: ". $url;
         }
     }
-    if ($encode) {
+    if ($decode) {
         return $json->utf8->canonical->decode($response->decoded_content);
     }
     return $response->decoded_content;
@@ -294,7 +294,6 @@ sub getSeriesField($$) {
 
     return $value;
 }
-
 
 # Adjust start and end times
 sub adjustCheckTime($$) {

--- a/files/worker/wfexec/event-timetable.pl
+++ b/files/worker/wfexec/event-timetable.pl
@@ -14,7 +14,7 @@ use JSON;
 
 my $debug = 0;
 my $oc_config = "/opt/opencast/etc/custom.properties";
-my $tt_ws = "http://srvslscet001.uct.ac.za/timetable/";
+my $tt_ws = "https://srvslscet001.uct.ac.za/timetable/";
 
 my %tt_comment;
 $tt_comment{'true'}  = "TIMETABLED event: edit and publish";

--- a/files/worker/wfexec/event-timetable.pl
+++ b/files/worker/wfexec/event-timetable.pl
@@ -2,12 +2,17 @@
 
 use strict;
 
+use Data::Dumper;
 use WWW::Mechanize;
 use LWP::Protocol::https;
-use Time::Local;
+use DateTime;
+use DateTime::Duration;
+use DateTime::Format::Duration;
+use DateTime::Format::W3CDTF;
 use Try::Tiny;
 use JSON;
 
+my $debug = 0;
 my $oc_config = "/opt/opencast/etc/custom.properties";
 my $tt_ws = "http://srvslscet001.uct.ac.za/timetable/";
 
@@ -16,8 +21,7 @@ $tt_comment{'true'}  = "TIMETABLED event: edit and publish";
 $tt_comment{'false'} = "Check CONSENT, edit and publish";
 
 my ($server, $oc_user, $oc_pass) = getOcAuth($oc_config);
-
-# print "server: $server user: $oc_user pass: $oc_pass\n";
+print "server: $server user: $oc_user pass: $oc_pass\n" if $debug;
 
 my $mpid = $ARGV[0];
 my $filename = $ARGV[1];
@@ -28,138 +32,102 @@ if (!defined($filename)) {
     $filename = "/dev/stdout";
 }
 
+my $w3c = DateTime::Format::W3CDTF->new;
+my $dfd_t = DateTime::Format::Duration->new( pattern => '%H:%M:%S' );
+
+my $json = new JSON;
+my $sleep = 30;
+$sleep = 1 if $debug;
+
+my $mech = WWW::Mechanize->new( autocheck => 0 );
+$mech->credentials($oc_user, $oc_pass);
+$mech->add_header( 'X-REQUESTED-AUTH' => 'Digest' );
+
 my $numEventAttempts = 0;
 
 my $timetable_completed = 0;
 my $timetable_result = "";
 my $timetabled = "false";
 my $visibility = "unknown";
-my $course = "unknown";
+my $course = "none";
 my $caption_provider = "unknown";
 my $location = "unknown";
+my $title = "unknown";
+my $series = "";
 my $tt_info = "none";
+my $tt_result = "false";
+my $event_trim = "true"; # Should this event be marked for trimming?
+my ($series, $event_date, $duration, $title, $start_time, $end_time) = ("","","","","","");
+($series, $event_date, $duration, $title, $start_time, $end_time) = getEventDetails($mech, $server, $mpid);
+print Dumper($series, $event_date, $duration, $title, $start_time, $end_time) if $debug;
 
-## Should this event be marked for trimming?
-my $event_trim = "true";
-
-try {
-  my $mech = WWW::Mechanize->new( autocheck => 0 );
-  $mech->credentials($oc_user, $oc_pass);
-  $mech->add_header( 'X-REQUESTED-AUTH' => 'Digest' );
-
-  my $json = new JSON;
-
-  ## Test event data
-
-  #my $series = "8d3ec06f-8c5a-499b-ac1f-aa2ee8841c01";
-  #my $course = "MAM1000W,2017";
-  #my $event_date="2017-08-14";
-  #my $start_time="08:00";
-  #my $end_time="08:50";
-  #my $location = "nlt";
-
-  ## Get the mediapackage info
-  my $event_metadata_json = getEventMetadata($mech, $server, $mpid);
-  my $event_m = $json->utf8->canonical->decode($event_metadata_json);
-
-  # Event fields - start_time is GMT
-
-  my $series         = getEventField($event_m, "isPartOf");
-  my $event_date     = getEventField($event_m, "startDate");
-  my $gmt_start_time = getEventField($event_m, "startTime");
-  my $duration       = getEventField($event_m, "duration");
-  my $title          = getEventField($event_m, "title");
-  my $start_time = GMT_LocalStartTime($event_date);
-
-  $location       = getEventField($event_m, "location");
-
-  # Date portion of W3CDTF format for startDate
-  $event_date = substr($event_date, 0, 10);
-
-  my $end_time = StartDuration_EndTime($event_date . "T" . $start_time, $duration);
-
-  # Don't mark for trim if this is a backup event
-  if ((index(lc($title), "[backup]") != -1) || (index(lc($title), "[hold]") != -1) ||
-      (index(lc($title), "(backup)") != -1) || (index(lc($title), "(hold)") != -1)) {
+# Don't mark for trim if this is a backup event
+if ((index(lc($title), "[backup]") != -1) || (index(lc($title), "[hold]") != -1) ||
+    (index(lc($title), "(backup)") != -1) || (index(lc($title), "(hold)") != -1) ||
+    ($title eq "unknown") || ($title eq "")) {
     $event_trim = "false";
-  }
+}
 
-  ## Get the series info
-  if (defined($series) && $series ne "") {
-      my $series_acl = getSeriesACL($mech, $server, $series);
+## Get the series info
+if (defined($series) && $series ne "") {
 
-      if ($series_acl =~ /ROLE_ANONYMOUS/) {
-        $visibility = "public";
-      } else {
-        $visibility = "vula";
-      }
+    ($visibility, $course, $caption_provider) = getSeriesDetails($mech, $server, $series);
+    print Dumper($visibility, $course, $caption_provider) if $debug;
 
-      my $series_metadata_json = getSeriesMetadata($mech, $server, $series);
-
-    if ($series_metadata_json ne "") {
-      my $series_m = $json->utf8->canonical->decode($series_metadata_json);
-        $course = getSeriesField($series_m, "course");
-        $caption_provider = getSeriesField($series_m, "caption-type");
-    }
-  }
-
-  ## Adjust the start and end times to cater for early start or late end
-  ($start_time, $end_time) = adjustCheckTime($start_time, $end_time);
-
-  ## Check with the timetable webservice
-  my $tt_result = "false";
-
-  if (!defined($course) || $course eq "") {
+    if (!defined($course) || $course eq "") {
       $course = "none";
-  }
+    }
 
-  if (($course ne "none") && defined($event_date) && defined($start_time) && defined($end_time) && defined($location)) {
-      my $tt = WWW::Mechanize->new( autocheck => 0 );
+    if ($course ne "none") {
+        if (!($course =~ /[\w]{3}[\d]{4}[\w]{1},[\d]{4}/)) {
+            die "Course Code ERROR: ". $course;
+        }
 
-      $tt->get($tt_ws . "?course=$course&event-date=$event_date&start=$start_time&end=$end_time&venue=$location");
-      my $response = $tt->response();
+        ## Check with the timetable webservice
+        if (($course =~ /[\w]{3}[\d]{4}[\w]{1},[\d]{4}/) && defined($event_date) && defined($start_time) && defined($end_time) && defined($location)) {
 
-      if (!$response->is_success) {
-        die "Unable to check timetable: " . $response->status_line;
-      } else {
-        $tt_result = $response->decoded_content;
-      }
-  }
+            my ($st, $et) = adjustCheckTime($start_time, $end_time);
 
-  ## Conclusion
-  if (($tt_result eq "true") && ($visibility ne "public")) {
-      $timetabled = "true";
-  }
+            my $tt_url = $tt_ws . "?course=$course&event-date=$event_date&start=$st&end=$et&venue=$location";
+            print "timetable_url: ". $tt_url ."\n" if $debug;
+            my $tt = WWW::Mechanize->new( autocheck => 0 );
+            $tt->get($tt_url);
+            my $response = $tt->response();
+            if (!$response->is_success) {
+                die "Timetable ERROR [". $response->status_line ."]: ". $tt_url;
+            } else {
+                $tt_result = $response->decoded_content;
+            }
+        }
+    }
+}
 
-  $tt_info = "$course;$location;$event_date;$start_time;$end_time;$visibility";
-  $timetable_completed = 1;
-} catch {
-  $timetable_completed = 0;
-  $timetable_result = $_;
-  chomp $timetable_result;
-} finally {
+## Conclusion
+if (($tt_result eq "true") && ($visibility ne "public")) {
+    $timetabled = "true";
+}
 
-  ## Write result
-  open(my $fh, '>', $filename) or die "Could not open result file '$filename' $!";
-  print $fh "timetabled=$timetabled\n";
-  print $fh "timetable_info=$tt_info\n";
-  print $fh "timetable_comment=" . $tt_comment{$timetabled} . "\n"  if ($timetable_completed);
-  print $fh "timetable_comment=" . $timetable_result . "\n"  if (!$timetable_completed);
-  print $fh "timetable_success=" . ($timetable_completed ? 'true' : 'false') . "\n";
-  print $fh "event_location=$location\n";
-  print $fh "event_trim=$event_trim\n";
-  print $fh "caption_provider=$caption_provider\n";
-  print $fh "use_watson=true\n" if ($caption_provider eq "watson");
-  print $fh "use_nibity=true\n" if ($caption_provider eq "nibity");
-  close $fh;
-};
+$tt_info = "$course;$location;$event_date;$start_time;$end_time;$visibility";
+$timetable_completed = 1;
+
+## Write result
+open(my $fh, '>', $filename) or die "File ERROR: failed to open result file '$filename' $!";
+print $fh "timetabled=$timetabled\n";
+print $fh "timetable_info=$tt_info\n";
+print $fh "timetable_comment=" . $tt_comment{$timetabled} . "\n"  if ($timetable_completed);
+print $fh "timetable_comment=" . $timetable_result . "\n"  if (!$timetable_completed);
+print $fh "timetable_success=" . ($timetable_completed ? 'true' : 'false') . "\n";
+print $fh "event_location=$location\n";
+print $fh "event_trim=$event_trim\n";
+print $fh "caption_provider=$caption_provider\n";
+print $fh "use_watson=true\n" if ($caption_provider eq "watson");
+print $fh "use_nibity=true\n" if ($caption_provider eq "nibity");
+close $fh;
 
 exit 0;
 
 ###############################################################
-
 # Get the digest auth configuration from the local config file
-
 sub getOcAuth($) {
 
   my $propsfile = shift;
@@ -187,166 +155,165 @@ sub getOcAuth($) {
   return ($url, $user, $pass);
 }
 
-# Series ACL
-
-sub getSeriesACL($$) {
-
-  my $mech = shift;
-  my $server = shift;
-  my $series = shift;
-  my $result = "";
-
-  $mech->get("$server/series/$series/acl.json");
-  my $response = $mech->response();
-  if (!$response->is_success) {
-    $timetable_completed = 0;
-    #$timetable_result = "Unable to get series ACL for series $series: " . $response->status_line;
-    die "Unable to get series ACL for series $series: " . $response->status_line;
-  } else {
-    $result = $response->decoded_content;
-  }
-
-  return $result;
-}
-
 # Series Metadata
+sub getSeriesDetails($$$) {
 
-sub getSeriesMetadata($$) {
+    my $mech = shift;
+    my $server = shift;
+    my $series_id = shift;
 
-  my $mech = shift;
-  my $server = shift;
-  my $series = shift;
-  my $result = "";
+    my $meta;
+    my ($visibility, $course, $caption_provider, $series_acl) = ("vula", "", "", "");
 
-  $mech->get("$server/api/series/$series/metadata");
-  my $response = $mech->response();
-  if (!$response->is_success) {
-    $timetable_completed = 0;
-    #$timetable_result = "Unable to get series metadata for series $series: " . $response->status_line;
-    die "Unable to get series metadata for series $series: " . $response->status_line;
-  } else {
-    $result = $response->decoded_content;
-  }
+    try {
+        $series_acl = getMetadata($mech, "$server/series/$series/acl.json", 0) =~ /ROLE_ANONYMOUS/;
+    } catch {
+        $series_acl = getMetadata($mech, "$server/admin-ng/series/$series/access.json", 0) =~ /ROLE_ANONYMOUS/;
+    };
 
-  return $result;
+    if ($series_acl) {
+        $visibility = "public";
+    }
+
+    try {
+        $meta = getMetadata($mech, "$server/api/series/$series/metadata", 1);
+    } catch {
+        $meta = getMetadata($mech, "$server/admin-ng/series/$series/metadata.json", 1);
+    };
+
+    if (defined($meta)) {
+        $course = getSeriesField($meta, "course");
+        $caption_provider = getSeriesField($meta, "caption-type");
+    }
+
+    return ($visibility, $course, $caption_provider)
 }
 
 # Event Metadata
-# /api/events/MPID?withacl=true&withmetadata=true to get location, start, duration, series (isPartOf), ACL, e.g.:
+sub getEventDetails($$$) {
 
-sub getEventMetadata($$) {
+    my $mech = shift;
+    my $server = shift;
+    my $mp = shift;
 
-  my $mech = shift;
-  my $server = shift;
-  my $mp = shift;
+    ## Get the mediapackage info from api / admin-ng
+    my ($series, $event_date, $duration, $title, $start_time, $end_time) = ("","","","","","");
+    try {
+        $numEventAttempts = 0;
+        my $event_m = getMetadata($mech, "$server/api/events/$mp/metadata?type=dublincore%2Fepisode", 1);
 
-  $mech->get("$server/api/events/$mp?withacl=true&withmetadata=true");
-  $numEventAttempts++;
-  my $response = $mech->response();
-  if (!$response->is_success) {
-    if ($numEventAttempts < 3) {
-      sleep(60);
-      return getEventMetadata($mech, $server, $mp);
-    } else {
-      die "Unable to get event metadata for event $mp: " . $response->status_line;
+        $series     = getEventField($event_m, "isPartOf", 0);
+        $event_date = $w3c->parse_datetime(getEventField($event_m, "startDate", 0) ."T". getEventField($event_m, "startTime", 0) ."Z");
+        $duration   = getEventField($event_m, "duration", 0);
+        $title      = getEventField($event_m, "title", 0);
+        $location   = getEventField($event_m, "location", 0);
+    } catch {
+        $numEventAttempts = 0;
+        my $event_m = getMetadata($mech, "$server/admin-ng/event/$mp/metadata.json", 1);
+
+        $series     = getEventField($event_m, "isPartOf", 1);
+        $event_date = $w3c->parse_datetime(getEventField($event_m, "startDate", 1));
+        $duration   = getEventField($event_m, "duration", 1);
+        $title      = getEventField($event_m, "title", 1);
+        $location   = getEventField($event_m, "location", 1);
+    };
+
+    my $local_time = $event_date->clone()->set_time_zone('GMT')->set_time_zone('Africa/Johannesburg');
+    my $local_end_time = $local_time + $dfd_t->parse_duration($duration);
+
+    $start_time = $local_time->strftime("%H:%M");
+    $event_date = $local_time->strftime("%Y-%m-%d");
+    $end_time   = $local_end_time->strftime("%H:%M");
+
+    return ($series, $event_date, $duration, $title, $start_time, $end_time);
+}
+
+sub getMetadata($$$) {
+    my $mech = shift;
+    my $url = shift;
+    my $encode = shift;
+
+    $mech->get($url);
+    $numEventAttempts++;
+    my $response = $mech->response();
+    if (!$response->is_success) {
+        if ($numEventAttempts < 3) {
+            sleep($sleep);
+            return getMetadata($mech, $url);
+        } else {
+            die "Metadata ERROR [". $response->status_line ."]: ". $url;
+        }
     }
-  }
-  return $response->decoded_content;
+    if ($encode) {
+        return $json->utf8->canonical->decode($response->decoded_content);
+    }
+    return $response->decoded_content;
 }
 
 # Get event field from JSON
+sub getEventField($$$) {
 
-sub getEventField($$) {
+    my $jhash = shift;
+    my $check = shift;
+    my $use_field = shift;
+    my $value;
 
-  my $jhash = shift;
-  my $field = shift;
-  my $value;
-
-  # For now assume we only have 1 metadata catalog for an event
-  foreach my $item (@{$jhash->{metadata}[0]->{fields}}) {
-    if ($item->{'id'} eq $field) {
-        $value = $item->{'value'};
+    if ($use_field) {
+        foreach my $fields (@{$jhash}[0]->{'fields'}) {
+            foreach my $item (@{$fields}) {
+                if ($item->{'id'} eq $check) {
+                    $value = $item->{'value'};
+                }
+            }
+        }
+    } else {
+        foreach my $field (@{$jhash}) {
+            if ($field->{'id'} eq $check) {
+                $value = $field->{'value'};
+            }
+        }
     }
-  }
 
-  return $value;
+    return $value;
 }
 
 # Get series field from JSON
-
 sub getSeriesField($$) {
 
-  my $jhash = shift;
-  my $field = shift;
-  my $value;
+    my $jhash = shift;
+    my $field = shift;
+    my $value;
 
-  foreach my $catalog (@{$jhash}) {
-    foreach my $item (@{$catalog->{fields}}) {
-        if ($item->{'id'} eq $field) {
-          $value = $item->{'value'};
+    foreach my $catalog (@{$jhash}) {
+        foreach my $item (@{$catalog->{fields}}) {
+            if ($item->{'id'} eq $field) {
+                $value = $item->{'value'};
+            }
         }
     }
-  }
 
-  return $value;
+    return $value;
 }
 
-# Convert to localtime, from http://www.perlmonks.org/?node_id=873435
-
-sub GMT_LocalStartTime
-{
-  my $t = shift;
-  my ($startDate, $startTime) = split(/T/,$t,2);
-  my ($year, $month, $day) =
-      $startDate =~ /(\d+)-(\d\d)-(\d\d)/;
-  my ($hour, $minute, $rest) = split(/:/, $startTime, 3);
-
-  my $epoch = timegm (0,0,$hour,$day,$month-1,$year);
-
-  my ($lyear,$lmonth,$lday,$lhour,$isdst) =
-            (localtime($epoch))[5,4,3,2,-1];
-
-  $lyear += 1900;  # year is 1900 based
-  $lmonth++;       # month number is zero based
-  return ( sprintf("%02d:%s", $lhour,$minute) );
-}
-
-# Calculate end time from start and duration
-
-sub StartDuration_EndTime
-{
-  my $start_dt = shift;
-  my $duration = shift;
-
-  my ($year, $month, $day, $hour, $min) = $start_dt =~ /(\d+)-(\d\d)-(\d\d)T(\d\d):(\d\d)/;
-  my $time = timelocal(0, $min, $hour, $day, $month-1, $year);
-  my ($d_h, $d_m, $d_s) = split(/:/, $duration);
-  my $endtime = $time + $d_s + $d_m * 60 + $d_h * 3600;
-  my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime($endtime);
-
-  return ( sprintf("%02d:%02d", $hour, $min) );
-}
 
 # Adjust start and end times
+sub adjustCheckTime($$) {
+    my $s = shift;
+    my $e = shift;
 
-sub adjustCheckTime($$)
-{
-  my $s = shift;
-  my $e = shift;
+    my ($s_h, $s_m) = $s =~ /(\d\d):(\d\d)/;
+    my ($e_h, $e_m) = $e =~ /(\d\d):(\d\d)/;
 
-  my ($s_h, $s_m) = $s =~ /(\d\d):(\d\d)/;
-  my ($e_h, $e_m) = $e =~ /(\d\d):(\d\d)/;
+    # Bump from hh:50 to start of next hour (hh+1:00)
+    if ($s_m >= 50) {
+        $s_h++;
+        $s = sprintf("%02d:00", $s_h);
+    }
 
-  # Bump from hh:50 to start of next hour (hh+1:00)
-  if ($s_m >= 50) {
-    $s_h++;
-    $s = sprintf("%02d:00", $s_h);
-  }
+    # Move end time back to :45.
+    if ($e_m > 45) {
+        $e = sprintf("%02d:45", $s_h);
+    }
 
-  # Move end time back to :45.
-  if ($e_m > 45) {
-    $e = sprintf("%02d:45", $s_h);
-  }
-
-  return ($s, $e);
+    return ($s, $e);
 }


### PR DESCRIPTION
Will **Fail** if:
1. Unable to open local Opencast properties file (`/opt/opencast/etc/custom.properties`)
2. Syntax is incorrect (mediapackageid output-file)
3. Event does not exist on `/api/events/` or `/admin-ng/event/`
4. Series does not exist on `/api/series/` or `/admin-ng/series/`
5. Course code is not in the proper format (`$course =~ /[\w]{3}[\d]{4}[\w]{1},[\d]{4}/`)
6. Timetable service fails to respond (`https://srvslscet001.uct.ac.za/timetable/`)



