### PR TITLE
OPENCAST-2386: Production and Dev deployes exactly the same folder configuration

### DIFF
--- a/files/config/conf-devubuopc001.cfg
+++ b/files/config/conf-devubuopc001.cfg
@@ -9,5 +9,5 @@ dir_lti = /var/www/vhosts/mediadev.uct.ac.za/ltitools
 server_url = https://mediadev.uct.ac.za
 assembly = adminpresentation
 assembly_display = Admin and Presentation
-dir_install_real = /data/opt/opencast
-dir_backup_real = /data/opt/opencast-bak
+dir_install_real = /opt/opencast
+dir_backup_real = /opt/opencast-bak

--- a/files/config/conf-example.cfg
+++ b/files/config/conf-example.cfg
@@ -9,5 +9,9 @@ dir_lti = /srv/www/vhosts/example.site.com/ltitools
 server_url = http://localhost:8080
 assembly = adminpresentation / worker / ingest
 assembly_display = Admin and Presentation / Worker / Ingest
-dir_install_real = /data/opt/opencast
-dir_backup_real = /data/opt/opencast-bak
+# Where it will actually be installed/extracted
+dir_install_real = /opt/opencast
+dir_backup_real = /opt/opencast-bak
+# Maybe in a linked folder
+#dir_install_real = /data/opt/opencast
+#dir_backup_real = /data/opt/opencast-bak

--- a/files/deploy.sh
+++ b/files/deploy.sh
@@ -20,8 +20,8 @@ PROGNAME=$(basename "$0")
 # assembly = adminpresentation
 # assembly_display = Admin and Presentation
 # server_url = http://mediadev.uct.ac.za
-# dir_install_real = /data/opt/opencast
-# dir_backup_real = /data/opt/opencast-bak
+# dir_install_real = /opt/opencast
+# dir_backup_real = /opt/opencast-bak
 
 main() {
 
@@ -59,7 +59,8 @@ main() {
   [ "$(ls -1 $working | wc -l)" -gt "0" ] && mv $working/* $bak/
   printf "."
 
-  [ "$(find -type f -name 'opencast-dist-*.tar.gz' -ls | wc -l)" -eq "1" ] && found_tar=true || found_tar=false
+
+  [ "$(find -maxdepth 1 -type f -name 'opencast-dist-*.tar.gz' -ls | wc -l)" -eq "1" ] && found_tar=true || found_tar=false
   if $found_tar; then
 
     # extract the assembly tar file to /opt folder then move content to the correct folder
@@ -67,7 +68,7 @@ main() {
     printf "."
 
     # remove the now empty extract folder
-    find $opt -type d -name "opencast-dist-*" -print0 | xargs -0 rm -r --
+    find $opt -maxdepth 1 -type d -name "opencast-dist-*" -print0 | xargs -0 rm -r --
     printf "."
   else
     echo
@@ -125,7 +126,6 @@ main() {
       chown -R mysql:mysql "$data/local/mysql"
     fi
   fi
-  # chown -R opencast:linux_cilt_admins $working_real/
   chown -R opencast:opencast $working_real/
   chmod g+w -R $working_real/
 
@@ -152,12 +152,11 @@ main() {
     $START_SERVICE && service opencast start
 
     echo
-    # OPENCAST-2386 - stop removing deployment files until we can sort out why it fails
-    #echo "    Cleaning ..."
-    #rm opencast-dist*.tar.gz
-    #rm deploy.cfg
-    #rm deploy.tar.gz
-    #rm ${PROGNAME};
+    echo "    Cleaning ..."
+    rm opencast-dist*.tar.gz
+    rm deploy.cfg
+    rm deploy.tar.gz
+    rm ${PROGNAME};
 
   else
 

--- a/files/deploy.sh
+++ b/files/deploy.sh
@@ -60,7 +60,7 @@ main() {
   printf "."
 
 
-  [ "$(find -maxdepth 1 -type f -name 'opencast-dist-*.tar.gz' -ls | wc -l)" -eq "1" ] && found_tar=true || found_tar=false
+  [ "$(find -L -maxdepth 1 -type f -name 'opencast-dist-*.tar.gz' -ls | wc -l)" -eq "1" ] && found_tar=true || found_tar=false
   if $found_tar; then
 
     # extract the assembly tar file to /opt folder then move content to the correct folder
@@ -68,7 +68,7 @@ main() {
     printf "."
 
     # remove the now empty extract folder
-    find $opt -maxdepth 1 -type d -name "opencast-dist-*" -print0 | xargs -0 rm -r --
+    find -L $opt -maxdepth 1 -type d -name "opencast-dist-*" -print0 | xargs -0 rm -r --
     printf "."
   else
     echo

--- a/files/lti.sh
+++ b/files/lti.sh
@@ -20,14 +20,14 @@ SERVER_NAME=$HOSTNAME
 # assembly = adminpresentation
 # assembly_display = Admin and Presentation
 # server_url = http://mediadev.uct.ac.za
-# dir_install_real = /data/opt/opencast
-# dir_backup_real = /data/opt/opencast-bak
+# dir_install_real = /opt/opencast
+# dir_backup_real = /opt/opencast-bak
 
 main() {
 
   opt=$( get_ini_value general dir_working )
   lti=$( get_ini_value general dir_lti )
-  
+
   cd $opt
 
   echo "Starting to deploy Opencast LTI Static files:"
@@ -37,7 +37,7 @@ main() {
   [ "$(find -type f -name lti*.tar.gz -ls | wc -l)" -eq "1" ] && found_tar=true || found_tar=false
 
   if $found_tar; then
- 
+
     printf "    Extracting $DEPLOY_DIR/$CONFIG_FILES as $USER"
 
     tar -zxf $DEPLOY_DIR/$CONFIG_FILES -C $lti/

--- a/files/reconfig.sh
+++ b/files/reconfig.sh
@@ -22,8 +22,8 @@ CLEANUP=true
 # assembly = adminpresentation
 # assembly_display = Admin and Presentation
 # server_url = http://mediadev.uct.ac.za
-# dir_install_real = /data/opt/opencast
-# dir_backup_real = /data/opt/opencast-bak
+# dir_install_real = /opt/opencast
+# dir_backup_real = /opt/opencast-bak
 
 main() {
 
@@ -84,7 +84,7 @@ main() {
       chown -R mysql:mysql "$data/local/mysql"
     fi
   fi
-  # chown -R opencast:linux_cilt_admins $working_real/
+
   chown -R opencast:opencast $working_real/
   chmod g+w -R $working_real/
 

--- a/files/rollback.sh
+++ b/files/rollback.sh
@@ -20,8 +20,8 @@ PROGNAME=$(basename "$0")
 # assembly = adminpresentation
 # assembly_display = Admin and Presentation
 # server_url = http://mediadev.uct.ac.za
-# dir_install_real = /data/opt/opencast
-# dir_backup_real = /data/opt/opencast-bak
+# dir_install_real = /opt/opencast
+# dir_backup_real = /opt/opencast-bak
 
 main() {
 
@@ -74,7 +74,7 @@ main() {
     $START_SERVICE && service opencast start
 
     echo
-   
+
     echo "    Cleaning ..."
     rm -rf $tmp_folder
     rm -rf $tmp_folder_real


### PR DESCRIPTION
as per Stephen's comment we make sure that dev and production deploys the same way - no symlink folders.

And restore the removal of the deployment files.

Fixed the deployment example by adding additional comments.