### PR TITLE
Add a comment to partial error

### DIFF
--- a/files/config/default/etc/workflows/partial-error.xml
+++ b/files/config/default/etc/workflows/partial-error.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definition xmlns="http://workflow.opencastproject.org">
+
+  <id>partial-error</id>
+  <description>Cleanup after a processing failure (UCT)</description>
+  <operations>
+
+    <!-- Comment that we cleaned up this recording -->
+    <operation
+      id="comment"
+      fail-on-error="false"
+      description="Comment that this recording has failed">
+      <configurations>
+        <configuration key="description">Recording has failed with a partial error.</configuration>
+        <configuration key="reason">EVENTS.EVENTS.DETAILS.COMMENTS.REASONS.PROCESSING_FAILURE</configuration>
+        <configuration key="action">create</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Archive the current state of the media package -->
+    <operation
+      id="snapshot"
+      fail-on-error="false"
+      description="Preserve the current recording state">
+      <configurations>
+        <configuration key="source-flavors">*/source,dublincore/*,security/*,captions/*</configuration>
+        <configuration key="source-tags">archive</configuration>
+      </configurations>
+    </operation>
+
+    <!-- Clean up the temporary files from the working file repository -->
+    <operation
+      id="cleanup"
+      fail-on-error="false"
+      description="Cleaning up">
+      <configurations>
+        <!-- On systems with shared workspace or working file repository -->
+        <!-- you want to set this option to false. -->
+        <configuration key="delete-external">true</configuration>
+        <!-- ACLs are required again when working through ActiveMQ messages -->
+        <configuration key="preserve-flavors">security/*</configuration>
+      </configurations>
+    </operation>
+
+  </operations>
+</definition>

--- a/files/deploy.sh
+++ b/files/deploy.sh
@@ -94,10 +94,7 @@ main() {
     cp $working/etc/workflows-default/cleanup-publish-placeholder.xml $working/etc/workflows/cleanup-publish-placeholder.xml
     cp $working/etc/workflows-default/delete.xml $working/etc/workflows/delete.xml
     cp $working/etc/workflows-default/import.xml $working/etc/workflows/import.xml
-    #cp $working/etc/workflows-default/google-speech-attach-transcripts.xml $working/etc/workflows/google-speech-attach-transcripts.xml
     cp $working/etc/workflows-default/google-speech-start-transcription.xml $working/etc/workflows/google-speech-start-transcription.xml
-    #cp $working/etc/workflows-default/nibity-start-transcription.xml $working/etc/workflows/nibity-start-transcription.xml
-    cp $working/etc/workflows-default/partial-error.xml $working/etc/workflows/partial-error.xml
     cp $working/etc/workflows-default/partial-retract.xml $working/etc/workflows/partial-retract.xml
     cp $working/etc/workflows-default/partial-title-slide.xml $working/etc/workflows/partial-title-slide.xml
     cp $working/etc/workflows-default/offload.xml $working/etc/workflows/offload.xml

--- a/files/reconfig.sh
+++ b/files/reconfig.sh
@@ -55,10 +55,7 @@ main() {
     cp $working/etc/workflows-default/cleanup-publish-placeholder.xml $working/etc/workflows/cleanup-publish-placeholder.xml
     cp $working/etc/workflows-default/delete.xml $working/etc/workflows/delete.xml
     cp $working/etc/workflows-default/import.xml $working/etc/workflows/import.xml
-    #cp $working/etc/workflows-default/google-speech-attach-transcripts.xml $working/etc/workflows/google-speech-attach-transcripts.xml
     cp $working/etc/workflows-default/google-speech-start-transcription.xml $working/etc/workflows/google-speech-start-transcription.xml
-    #cp $working/etc/workflows-default/nibity-start-transcription.xml $working/etc/workflows/nibity-start-transcription.xml
-    #cp $working/etc/workflows-default/partial-error.xml $working/etc/workflows/partial-error.xml
     cp $working/etc/workflows-default/partial-retract.xml $working/etc/workflows/partial-retract.xml
     cp $working/etc/workflows-default/partial-title-slide.xml $working/etc/workflows/partial-title-slide.xml
     cp $working/etc/workflows-default/offload.xml $working/etc/workflows/offload.xml

--- a/files/reconfig.sh
+++ b/files/reconfig.sh
@@ -58,7 +58,7 @@ main() {
     #cp $working/etc/workflows-default/google-speech-attach-transcripts.xml $working/etc/workflows/google-speech-attach-transcripts.xml
     cp $working/etc/workflows-default/google-speech-start-transcription.xml $working/etc/workflows/google-speech-start-transcription.xml
     #cp $working/etc/workflows-default/nibity-start-transcription.xml $working/etc/workflows/nibity-start-transcription.xml
-    cp $working/etc/workflows-default/partial-error.xml $working/etc/workflows/partial-error.xml
+    #cp $working/etc/workflows-default/partial-error.xml $working/etc/workflows/partial-error.xml
     cp $working/etc/workflows-default/partial-retract.xml $working/etc/workflows/partial-retract.xml
     cp $working/etc/workflows-default/partial-title-slide.xml $working/etc/workflows/partial-title-slide.xml
     cp $working/etc/workflows-default/offload.xml $working/etc/workflows/offload.xml


### PR DESCRIPTION
There's a need to add a comment to partial error.  Copied across the partial error in OC 14.x and added a comment operation so that we leave an open comment when a workflow fails.

This helps us see errors because as the default filter for errors is:
<img width="375" alt="Screenshot 2023-11-20 at 22 12 23" src="https://github.com/cilt-uct/oc-scripts/assets/18629266/09b72fc9-456f-4446-8586-cf76dc9f9e80">
