### PR TITLE
OPENCAST-3228: Replace compositeCommand with ffmpeg command

### DIFF
--- a/files/config/default/etc/encoding/uct.properties
+++ b/files/config/default/etc/encoding/uct.properties
@@ -31,12 +31,15 @@
 # https://trac.ffmpeg.org/ticket/6375
 
 # similar to uct-mp4-preview.dual.http
-profile.mp4-download.dual.http.name = download video video (picture-by-picture)
+profile.mp4-download.dual.http.name = download video (picture-by-picture)
 profile.mp4-download.dual.http.input = visual
 profile.mp4-download.dual.http.output = visual
-profile.mp4-download.dual.http.suffix = -composite.mp4
+profile.mp4-download.dual.http.suffix = -download-composite.mp4
 profile.mp4-download.dual.http.mimetype = video/mp4
-profile.mp4-download.dual.http.ffmpeg.command = -i #{in.video.path} #{compositeCommand} -c:v libx264 -preset medium -crf 23 -r 25 -profile:v high -pix_fmt yuv420p -tune film -movflags faststart -c:a aac -strict -2 -ar 44100 -ab 128k #{out.dir}/#{out.name}#{out.suffix}
+profile.mp4-download.dual.http.ffmpeg.command = -i #{in.video.path} -i #{upperFile} -filter_complex \
+  [0:v]scale=#{scaleLower},pad=#{padLower}[lower];[1:v]scale=#{scaleUpper}[upper];[lower][upper]overlay=#{upperPosition}[out]#{audioMapping} \
+  -c:v libx264 -preset medium crf 23 -r 25 -profile:v high -pix_fmt yuv420p -tune film \
+  -c:a aac -strict -2 -ar 44100 -ab 128k -movflags faststart #{out.dir}/#{out.name}#{out.suffix}
 profile.mp4-download.dual.http.jobload = 2.5
 
 ####################################################################################
@@ -378,7 +381,11 @@ profile.uct-mp4-preview.dual.http.name = preview video (picture-by-picture)
 profile.uct-mp4-preview.dual.http.input = visual
 profile.uct-mp4-preview.dual.http.output = visual
 profile.uct-mp4-preview.dual.http.suffix = -preview-composite.mp4
-profile.uct-mp4-preview.dual.http.ffmpeg.command = -i #{in.video.path} #{compositeCommand} -c:v libx264 -preset veryfast -crf 23 -profile:v baseline -pix_fmt yuv420p -tune film -movflags faststart -c:a aac -strict -2 -ar 44100 -ab 128k -max_muxing_queue_size 81920 #{out.dir}/#{out.name}#{out.suffix}
+profile.uct-mp4-preview.dual.http.ffmpeg.command = -i #{in.video.path} -i #{upperFile} -filter_complex \
+  [0:v]scale=#{scaleLower},pad=#{padLower}[lower];[1:v]scale=#{scaleUpper}[upper];[lower][upper]overlay=#{upperPosition}[out]#{audioMapping} \
+  -c:v libx264 -preset veryfast -crf 23 -profile:v baseline -pix_fmt yuv420p -tune film \
+  -c:a aac -strict -2 -ar 44100 -ab 128k -max_muxing_queue_size 81920 \
+  -movflags faststart #{out.dir}/#{out.name}#{out.suffix}
 profile.uct-mp4-preview.dual.http.jobload = 2.5
 
 ####################################################################################

--- a/files/config/default/etc/workflows/uct-include-partial-download-abde.xml
+++ b/files/config/default/etc/workflows/uct-include-partial-download-abde.xml
@@ -52,7 +52,7 @@
             <configuration key="source-flavor-lower">composite/inter</configuration>
             <configuration key="encoding-profile">mp4-download.dual.http</configuration>
             <configuration key="target-flavor">composite/delivery</configuration>
-            <configuration key="target-tags">rss,atom,composite</configuration>
+            <configuration key="target-tags">rss,atom,composite,engage-download</configuration>
             <configuration key="output-resolution">1440x540</configuration>
             <configuration key="output-background">0x000000FF</configuration>
             <configuration key="layout">preview</configuration>

--- a/files/config/default/etc/workflows/uct-include-picture-in-picture-bottom-left.xml
+++ b/files/config/default/etc/workflows/uct-include-picture-in-picture-bottom-left.xml
@@ -29,8 +29,8 @@
         <configuration key="source-flavor-upper">presenter/${result_publish_process}</configuration>
         <configuration key="encoding-profile">mp4-download.dual.http</configuration>
         <configuration key="target-flavor">pic-in-pic1/delivery</configuration>
-        <configuration key="target-tags">rss,atom</configuration>
-	      <configuration key="output-resolution">1920x1080</configuration>
+        <configuration key="target-tags">rss,atom,engage-download</configuration>
+        <configuration key="output-resolution">1920x1080</configuration>
         <configuration key="output-background">0x000000FF</configuration>
         <configuration key="layout">preview</configuration>
         <configuration key="layout-single">
@@ -54,8 +54,8 @@
         <configuration key="source-flavor-upper">presenter/${result_publish_process}</configuration>
         <configuration key="encoding-profile">mp4-download.dual.http</configuration>
         <configuration key="target-flavor">pic-in-pic2/delivery</configuration>
-        <configuration key="target-tags">rss,atom</configuration>
-	      <configuration key="output-resolution">1920x1080</configuration>
+        <configuration key="target-tags">rss,atom,engage-download</configuration>
+        <configuration key="output-resolution">1920x1080</configuration>
         <configuration key="output-background">0x000000FF</configuration>
         <configuration key="layout">preview</configuration>
         <configuration key="layout-single">

--- a/files/config/default/etc/workflows/uct-include-picture-in-picture-bottom-right.xml
+++ b/files/config/default/etc/workflows/uct-include-picture-in-picture-bottom-right.xml
@@ -29,7 +29,7 @@
         <configuration key="source-flavor-upper">presenter/${result_publish_process}</configuration>
         <configuration key="encoding-profile">mp4-download.dual.http</configuration>
         <configuration key="target-flavor">pic-in-pic1/delivery</configuration>
-        <configuration key="target-tags">rss,atom</configuration>
+        <configuration key="target-tags">rss,atom,engage-download</configuration>
         <configuration key="output-resolution">1920x1080</configuration>
         <configuration key="output-background">0x000000FF</configuration>
         <configuration key="layout">preview</configuration>
@@ -54,8 +54,8 @@
         <configuration key="source-flavor-upper">presenter/${result_publish_process}</configuration>
         <configuration key="encoding-profile">mp4-download.dual.http</configuration>
         <configuration key="target-flavor">pic-in-pic2/delivery</configuration>
-        <configuration key="target-tags">rss,atom</configuration>
-	      <configuration key="output-resolution">1920x1080</configuration>
+        <configuration key="target-tags">rss,atom,engage-download</configuration>
+        <configuration key="output-resolution">1920x1080</configuration>
         <configuration key="output-background">0x000000FF</configuration>
         <configuration key="layout">preview</configuration>
         <configuration key="layout-single">

--- a/files/config/default/etc/workflows/uct-include-picture-in-picture-top-left.xml
+++ b/files/config/default/etc/workflows/uct-include-picture-in-picture-top-left.xml
@@ -29,8 +29,8 @@
         <configuration key="source-flavor-upper">presenter/${result_publish_process}</configuration>
         <configuration key="encoding-profile">mp4-download.dual.http</configuration>
         <configuration key="target-flavor">pic-in-pic1/delivery</configuration>
-        <configuration key="target-tags">rss,atom</configuration>
-	      <configuration key="output-resolution">1920x1080</configuration>
+        <configuration key="target-tags">rss,atom,engage-download</configuration>
+        <configuration key="output-resolution">1920x1080</configuration>
         <configuration key="output-background">0x000000FF</configuration>
         <configuration key="layout">preview</configuration>
         <configuration key="layout-single">
@@ -54,8 +54,8 @@
         <configuration key="source-flavor-upper">presenter/${result_publish_process}</configuration>
         <configuration key="encoding-profile">mp4-download.dual.http</configuration>
         <configuration key="target-flavor">pic-in-pic2/delivery</configuration>
-	      <configuration key="target-tags">rss,atom</configuration>
-	      <configuration key="output-resolution">1920x1080</configuration>
+        <configuration key="target-tags">rss,atom,engage-download</configuration>
+        <configuration key="output-resolution">1920x1080</configuration>
         <configuration key="output-background">0x000000FF</configuration>
         <configuration key="layout">preview</configuration>
         <configuration key="layout-single">

--- a/files/config/default/etc/workflows/uct-include-picture-in-picture-top-right.xml
+++ b/files/config/default/etc/workflows/uct-include-picture-in-picture-top-right.xml
@@ -29,7 +29,7 @@
         <configuration key="source-flavor-upper">presenter/${result_publish_process}</configuration>
         <configuration key="encoding-profile">mp4-download.dual.http</configuration>
         <configuration key="target-flavor">pic-in-pic1/delivery</configuration>
-	      <configuration key="target-tags">rss,atom</configuration>
+        <configuration key="target-tags">rss,atom,engage-download</configuration>
         <configuration key="output-resolution">1920x1080</configuration>
         <configuration key="output-background">0x000000FF</configuration>
         <configuration key="layout">preview</configuration>
@@ -54,7 +54,7 @@
         <configuration key="source-flavor-upper">presenter/${result_publish_process}</configuration>
         <configuration key="encoding-profile">mp4-download.dual.http</configuration>
         <configuration key="target-flavor">pic-in-pic2/delivery</configuration>
-	      <configuration key="target-tags">rss,atom</configuration>
+        <configuration key="target-tags">rss,atom,engage-download</configuration>
         <configuration key="output-resolution">1920x1080</configuration>
         <configuration key="output-background">0x000000FF</configuration>
         <configuration key="layout">preview</configuration>

--- a/files/config/default/etc/workflows/uct-include-picture-in-picture.xml
+++ b/files/config/default/etc/workflows/uct-include-picture-in-picture.xml
@@ -35,16 +35,16 @@
       description="Untag all pic-in-pic1 flavors">
       <configurations>
         <configuration key="source-flavors">pic-in-pic1/delivery</configuration>
-        <configuration key="target-tags">-rss,-atom,</configuration>
+        <configuration key="target-tags">-rss,-atom,-engage-download</configuration>
       </configurations>
     </operation>
 
     <operation
       id="tag"
-      description="Untag all pic-in-pic1 flavors">
+      description="Untag all pic-in-pic2 flavors">
       <configurations>
         <configuration key="source-flavors">pic-in-pic2/delivery</configuration>
-        <configuration key="target-tags">-rss,-atom,</configuration>
+        <configuration key="target-tags">-rss,-atom,-engage-download</configuration>
       </configurations>
     </operation>
 

--- a/files/config/default/etc/workflows/uct-partial-publish-downloads.xml
+++ b/files/config/default/etc/workflows/uct-partial-publish-downloads.xml
@@ -24,7 +24,7 @@
       description="Untag all composite flavors">
       <configurations>
         <configuration key="source-flavors">composite/delivery</configuration>
-        <configuration key="target-tags">-rss,-atom,-composite</configuration>
+        <configuration key="target-tags">-rss,-atom,-composite,-engage-download</configuration>
       </configurations>
     </operation>
 
@@ -49,7 +49,7 @@
         <configuration key="source-flavor-upper">presenter/${result_publish_process}</configuration>
         <configuration key="encoding-profile">mp4-download.dual.http</configuration>
         <configuration key="target-flavor">composite/delivery</configuration>
-        <configuration key="target-tags">rss,atom,composite</configuration>
+        <configuration key="target-tags">rss,atom,composite,engage-download</configuration>
         <configuration key="output-resolution">2560x720</configuration>
         <configuration key="output-background">0x000000FF</configuration>
         <configuration key="layout">preview</configuration>
@@ -74,7 +74,7 @@
         <configuration key="source-flavor-upper">presenter/${result_publish_process}</configuration>
         <configuration key="encoding-profile">mp4-download.dual.http</configuration>
         <configuration key="target-flavor">composite/delivery</configuration>
-        <configuration key="target-tags">rss,atom,composite</configuration>
+        <configuration key="target-tags">rss,atom,composite,engage-download</configuration>
         <configuration key="output-resolution">2560x720</configuration>
         <configuration key="output-background">0x000000FF</configuration>
         <configuration key="layout">preview</configuration>
@@ -99,7 +99,7 @@
         <configuration key="source-flavor-upper">presentation/${result_publish_process}</configuration>
         <configuration key="encoding-profile">mp4-download.dual.http</configuration>
         <configuration key="target-flavor">composite/delivery</configuration>
-        <configuration key="target-tags">rss,atom,composite</configuration>
+        <configuration key="target-tags">rss,atom,composite,engage-download</configuration>
         <configuration key="output-resolution">2560x720</configuration>
         <configuration key="output-background">0x000000FF</configuration>
         <configuration key="layout">preview</configuration>


### PR DESCRIPTION
and include engage-download target tags on picture-in-picture workflows